### PR TITLE
fix: hover color for scrollbar (replacing red for debugging)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### *upcoming*
 
  - Add default terminal colors, https://github.com/MadLittleMods/zed-theme-vscode-light-plus/pull/1
- - Add new vscode scrollbar color. Contributed by @iamDecode, https://github.com/MadLittleMods/zed-theme-vscode-light-plus/pull/2
+ - Align scrollbar colors to upstream theme (including scrollbar hover color). Contributed by @iamDecode, https://github.com/MadLittleMods/zed-theme-vscode-light-plus/pull/2
 
 
 ### `v0.0.1` - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### *upcoming*
 
  - Add default terminal colors, https://github.com/MadLittleMods/zed-theme-vscode-light-plus/pull/1
+ - Add new vscode scrollbar color. Contributed by @iamDecode, https://github.com/MadLittleMods/zed-theme-vscode-light-plus/pull/2
 
 
 ### `v0.0.1` - Initial release

--- a/themes/vscode-light-plus.json
+++ b/themes/vscode-light-plus.json
@@ -51,11 +51,12 @@
         "panel.indent_guide_active": "#616161",
         "panel.indent_guide_hover": "#e4e6f1",
         // Scrollbar
-        "scrollbar.thumb.background": "#dddddd",
-        "scrollbar.thumb.hover_background": "#f00",
-        "scrollbar.thumb.border": "#dddddd",
+        "scrollbar.thumb.background": "#c1c1c1",
+        "scrollbar.thumb.hover_background": "#929292",
+        "scrollbar.thumb.active_background": "#929292",
+        "scrollbar.thumb.border": "#c1c1c1",
         "scrollbar.track.background": "#00000000",
-        "scrollbar.track.border": "#dddddd",
+        "scrollbar.track.border": "#c1c1c1",
         // Elements like  Buttons, Inputs, Checkboxes, Radio Buttons
         // --------------------------------------------------------------
         // "element.background": "#f00",


### PR DESCRIPTION
I've noticed in more recent versions of Zed the scrollbar hover state is pure red. It seem that `#f00` is used for debugging and ended up for the scrollbar hover state by accident. This suggestion turns it into a slightly darker grey :)

Zed 0.188.5 on macOS Sequoia 15.5 (24F74)

## Before
https://github.com/user-attachments/assets/95f96514-b581-455b-a025-70298f5d53cc

## After

(the hover color has since been updated to be darker)

https://github.com/user-attachments/assets/83647a7b-61b4-4260-83a7-41fcb79f656b



